### PR TITLE
Remove Underscores Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ A collection of plugins, starter themes and tools to make WordPress development 
 * [Toggle wpautop](https://wordpress.org/plugins/toggle-wpautop/) - Allows the disabling of wpautop filter on a Post by Post basis. Toggle can also be enabled on a Post Type by Post Type basis or globally.
 * [Transients Manager](https://wordpress.org/plugins/transients-manager/) - Provides a UI to manage your site's transients. You can view, search, edit, and delete transients at will.
 * [Underscores](https://github.com/Automattic/_s) - Hi. I'm a starter theme called _s, or underscores, if you like. I'm a theme meant for hacking so don't use me as a Parent Theme. Instead try turning me into the next, most awesome, WordPress theme out there.
-* [Underscores Components](http://components.underscores.me/) - Build a solid foundation for your WordPress project with the Components starter-theme generator.
 * [Useful WordPress Functions](https://github.com/taniaraschttps://github.com/lucatume/wp-browseria/wp-functions) - This is a list of useful WordPress functions that I often reference to enhance or clean up my sites.
 * [User Session Control](https://wordpress.org/plugins/user-session-control/) - View and manage all active user sessions in a custom admin screen.
 * [Unyson](https://wordpress.org/plugins/unyson/) - A free drag & drop framework that comes with a bunch of built in extensions that will help you develop premium themes fast & easy.


### PR DESCRIPTION
This project was retired in June 2017, one contributing author citing "...we hit a point where we realized we had over-engineered parts of the project...we’re retiring Components, and looking to bring some of what we learned there to Underscores."[1]

Long live _s Components!

[1] https://themeshaper.com/2017/06/26/the-future-of-underscores-and-a-new-committer/