### PR TITLE
Add WP Multitool to WordPress plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ A collection of plugins, starter themes and tools to make WordPress development 
 * [WP Media Metadata Fix](https://wordpress.org/plugins/wp-media-metadata-fix/) - Fixes the metadata of the images in the Media library.
 * [WP Migrate DB Anonymization](https://wordpress.org/plugins/wp-migrate-db-anonymization/) - An extension to WP Migrate DB and WP Migrate DB Pro that anonymizes user data.
 * [WP Monitor](https://wordpress.org/plugins/wp-monitor/) - Collects important data from site and displays it on the dashboard.
+* [WP Multitool](https://wpmultitool.com) - AI-powered WordPress performance and developer toolkit. Identifies slow database queries with AI analysis, manages bulk plugin/theme updates, exports/imports wp-config.php settings. Modular zero-bloat architecture.
 * [WP Notification Center](https://wordpress.org/plugins/wp-notification-center/) - Adds a notification center to WordPress, no more pages that are cluttered with notifications.
 * [WP Original Media Path](https://wordpress.org/plugins/wp-original-media-path/) - Change the location for the uploads folder for WordPress.
 * [WordPress-Gear](https://github.com/wecodemore/WordPress-Gear) - A bunch of gear for WP developers.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ A collection of plugins, starter themes and tools to make WordPress development 
 * [WP Media Metadata Fix](https://wordpress.org/plugins/wp-media-metadata-fix/) - Fixes the metadata of the images in the Media library.
 * [WP Migrate DB Anonymization](https://wordpress.org/plugins/wp-migrate-db-anonymization/) - An extension to WP Migrate DB and WP Migrate DB Pro that anonymizes user data.
 * [WP Monitor](https://wordpress.org/plugins/wp-monitor/) - Collects important data from site and displays it on the dashboard.
-* [WP Multitool](https://wpmultitool.com) - AI-powered WordPress performance and developer toolkit. Identifies slow database queries with AI analysis, manages bulk plugin/theme updates, exports/imports wp-config.php settings. Modular zero-bloat architecture.
+* [WP Multitool](https://wpmultitool.com) - WordPress performance and developer toolkit. Identifies slow database queries, manages bulk plugin/theme updates, exports/imports wp-config.php settings. Modular zero-bloat architecture.
 * [WP Notification Center](https://wordpress.org/plugins/wp-notification-center/) - Adds a notification center to WordPress, no more pages that are cluttered with notifications.
 * [WP Original Media Path](https://wordpress.org/plugins/wp-original-media-path/) - Change the location for the uploads folder for WordPress.
 * [WordPress-Gear](https://github.com/wecodemore/WordPress-Gear) - A bunch of gear for WP developers.


### PR DESCRIPTION
## What's added

[WP Multitool](https://wpmultitool.com) — WordPress performance and developer toolkit (14 modules).

**Why it fits:**
- System Info: PHP, WP, MySQL, server, caching details at a glance
- Config Manager: GUI editor for wp-config.php constants with backup/restore
- Shortcode Inspector: lists and analyzes all registered shortcodes
- Slow Query Analyzer: MySQL EXPLAIN analysis + CREATE INDEX suggestions (fully local)
- Find Slow Callbacks: profiles action/filter hook performance
- WP-CLI: 7 subcommands (status, health, db-health, autoload, slow-queries, frontend, clean)
- Modular: disabled modules = zero overhead
